### PR TITLE
fix: Project path not mapped correctly to Claude Code query options

### DIFF
--- a/nodes/ClaudeCode/ClaudeCode.node.ts
+++ b/nodes/ClaudeCode/ClaudeCode.node.ts
@@ -235,7 +235,6 @@ export class ClaudeCode implements INodeType {
 				interface QueryOptions {
 					prompt: string;
 					abortController: AbortController;
-					cwd?: string;
 					options: {
 						maxTurns: number;
 						permissionMode: 'default' | 'bypassPermissions';
@@ -244,6 +243,7 @@ export class ClaudeCode implements INodeType {
 						mcpServers?: Record<string, any>;
 						allowedTools?: string[];
 						continue?: boolean;
+						cwd?: string;
 					};
 				}
 
@@ -264,9 +264,9 @@ export class ClaudeCode implements INodeType {
 
 				// Add project path (cwd) if specified
 				if (projectPath && projectPath.trim() !== '') {
-					queryOptions.cwd = projectPath.trim();
+					queryOptions.options.cwd = projectPath.trim();
 					if (additionalOptions.debug) {
-						console.log(`[ClaudeCode] Working directory set to: ${queryOptions.cwd}`);
+						console.log(`[ClaudeCode] Working directory set to: ${queryOptions.options.cwd}`);
 					}
 				}
 


### PR DESCRIPTION
This PR fixes the wrongly mapped query options. At the moment, the setting `Project path` doesn't do anything because it's passed to a non-existent property in Claude Code. Because of this, Claude Code starts in `/home/node` instead of the provided project path.