### PR TITLE
Fix: Replace @anthropic-ai/claude-code with @anthropic-ai/claude-agent-sdk

### DIFF
--- a/nodes/ClaudeCode/ClaudeCode.node.ts
+++ b/nodes/ClaudeCode/ClaudeCode.node.ts
@@ -5,7 +5,7 @@ import type {
 	INodeTypeDescription,
 } from 'n8n-workflow';
 import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
-import { query, type SDKMessage } from '@anthropic-ai/claude-code';
+import { query, type SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 
 export class ClaudeCode implements INodeType {
 	description: INodeTypeDescription = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@holtweb/n8n-nodes-claudecode",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holtweb/n8n-nodes-claudecode",
-      "version": "0.1.1",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-code": "latest"
+        "@anthropic-ai/claude-agent-sdk": "latest"
       },
       "devDependencies": {
         "@types/node": "^22.13.10",
@@ -27,14 +27,11 @@
         "n8n-workflow": "*"
       }
     },
-    "node_modules/@anthropic-ai/claude-code": {
-      "version": "1.0.56",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.56.tgz",
-      "integrity": "sha512-LYOlv9uXtLrJcJqSLvQlhy7shhC6MHEXuSGZ/+BazM4LY36ng3cmKjTCDny0kZQxa+u/+MYOXUrkmkJm2qR75Q==",
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.1.30.tgz",
+      "integrity": "sha512-lo1tqxCr2vygagFp6kUMHKSN6AAWlULCskwGKtLB/JcIXy/8H8GsLSKX54anTsvc9mBbCR8wWASdFmiiL9NSKA==",
       "license": "SEE LICENSE IN README.md",
-      "bin": {
-        "claude": "cli.js"
-      },
       "engines": {
         "node": ">=18.0.0"
       },
@@ -45,6 +42,9 @@
         "@img/sharp-linux-arm64": "^0.33.5",
         "@img/sharp-linux-x64": "^0.33.5",
         "@img/sharp-win32-x64": "^0.33.5"
+      },
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     ]
   },
   "dependencies": {
-    "@anthropic-ai/claude-code": "latest"
+    "@anthropic-ai/claude-agent-sdk": "latest"
   },
   "devDependencies": {
     "@types/node": "^22.13.10",


### PR DESCRIPTION
## Problem

Fixes #8

The package was unable to load due to a missing module error:
```
Cannot find module '/home/node/.n8n/nodes/node_modules/@holtweb/n8n-nodes-claudecode/node_modules/@anthropic-ai/claude-code/sdk.mjs'
```

## Root Cause

The package was using `@anthropic-ai/claude-code` which is **CLI-only** and does not export a programmable SDK.

Looking at the published package:
- It declares `"main": "sdk.mjs"` in package.json
- But `sdk.mjs` file **does not exist** in the package
- Only `cli.js` exists (the bundled CLI binary)

## Solution

Replace `@anthropic-ai/claude-code` with `@anthropic-ai/claude-agent-sdk` which is the correct package for programmatic usage.

According to the official documentation: https://docs.claude.com/en/api/agent-sdk/overview

- `@anthropic-ai/claude-agent-sdk` is the TypeScript SDK for building agents
- It properly exports the `query()` function and `SDKMessage` type

## Changes

- `package.json`: Changed dependency from `@anthropic-ai/claude-code` to `@anthropic-ai/claude-agent-sdk`
- `nodes/ClaudeCode/ClaudeCode.node.ts`: Updated import statement to use the correct package

## Testing

✅ Built successfully with `npm run build`
✅ Installed and tested in n8n 1.118.2
✅ Node loads without errors
✅ Successfully executed a test query
✅ All tools and agents properly initialized

**Test Result:**
The node now works correctly and returns proper responses from Claude with all tools (Task, Bash, Read, Write, WebFetch, etc.) available.

## Additional Notes

This is a minimal change that only updates the package name. The API surface of `@anthropic-ai/claude-agent-sdk` is compatible with the existing code - both export the same `query()` function and `SDKMessage` type.