### PR TITLE
fix: migrate from deprecated @anthropic-ai/claude-code to @anthropic-ai/claude-agent-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,14 @@ Transform support tickets into code fixes automatically:
 ## ⚡ Quick Start
 
 ### Prerequisites
-1. **Claude Code CLI** (required on your n8n server):
+1. **Claude Code** (required on your n8n server):
    ```bash
-   npm install -g @anthropic-ai/claude-code
-   claude  # Authenticate (requires Claude Pro/Team subscription)
+   # Install Claude Code CLI
+   curl -fsSL https://claude.ai/install.sh | bash
+   # Or on Windows: winget install Anthropic.ClaudeCode
+   
+   # Authenticate (requires API key or Claude Pro/Team subscription)
+   claude
    ```
 
 ### Install in n8n

--- a/nodes/ClaudeCode/ClaudeCode.node.ts
+++ b/nodes/ClaudeCode/ClaudeCode.node.ts
@@ -5,7 +5,7 @@ import type {
 	INodeTypeDescription,
 } from 'n8n-workflow';
 import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
-import { query, type SDKMessage } from '@anthropic-ai/claude-code';
+import { query, type SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 
 export class ClaudeCode implements INodeType {
 	description: INodeTypeDescription = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@holtweb/n8n-nodes-claudecode",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holtweb/n8n-nodes-claudecode",
-      "version": "0.1.1",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-code": "latest"
+        "@anthropic-ai/claude-agent-sdk": "latest"
       },
       "devDependencies": {
         "@types/node": "^22.13.10",
@@ -27,14 +27,11 @@
         "n8n-workflow": "*"
       }
     },
-    "node_modules/@anthropic-ai/claude-code": {
-      "version": "1.0.56",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.56.tgz",
-      "integrity": "sha512-LYOlv9uXtLrJcJqSLvQlhy7shhC6MHEXuSGZ/+BazM4LY36ng3cmKjTCDny0kZQxa+u/+MYOXUrkmkJm2qR75Q==",
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.9.tgz",
+      "integrity": "sha512-b4JD6ZKCZeVDqpWBnb+zJISWi3HzlweNlV7Oy/uo5G2XAfUV2M5AJ/tomKZCvZsvmr1fYbmmfyde3GL2h0pksA==",
       "license": "SEE LICENSE IN README.md",
-      "bin": {
-        "claude": "cli.js"
-      },
       "engines": {
         "node": ">=18.0.0"
       },
@@ -44,7 +41,12 @@
         "@img/sharp-linux-arm": "^0.33.5",
         "@img/sharp-linux-arm64": "^0.33.5",
         "@img/sharp-linux-x64": "^0.33.5",
+        "@img/sharp-linuxmusl-arm64": "^0.33.5",
+        "@img/sharp-linuxmusl-x64": "^0.33.5",
         "@img/sharp-win32-x64": "^0.33.5"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -356,6 +358,38 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-linux-arm": {
       "version": "0.33.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
@@ -420,6 +454,50 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
@@ -3616,6 +3694,16 @@
         "zod": "3.24.1"
       }
     },
+    "node_modules/n8n-workflow/node_modules/zod": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -5199,9 +5287,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
-      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
+      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@holtweb/n8n-nodes-claudecode",
-  "version": "0.2.1",
-  "description": "n8n node for Claude Code SDK integration with MCP support",
+  "version": "0.3.0",
+  "description": "n8n node for Claude Agent SDK integration with MCP support",
   "keywords": [
     "n8n-community-node-package",
     "n8n",
@@ -47,7 +47,7 @@
     ]
   },
   "dependencies": {
-    "@anthropic-ai/claude-code": "latest"
+    "@anthropic-ai/claude-agent-sdk": "latest"
   },
   "devDependencies": {
     "@types/node": "^22.13.10",


### PR DESCRIPTION
# Fix: Migrate from deprecated @anthropic-ai/claude-code to @anthropic-ai/claude-agent-sdk

Fixes #8

## Summary

The `@anthropic-ai/claude-code` npm package has been deprecated and renamed to `@anthropic-ai/claude-agent-sdk`. The old package is now CLI-only and no longer exports the SDK functionality (`query`, `SDKMessage`), causing this community node to fail with:

```
Cannot find module '@anthropic-ai/claude-code'
```

This PR updates the package to use the new SDK package name.

> **Note:** This is essentially the same fix as PR #9 by @Mister-Wolfgang, which was closed when they deleted their fork. Resubmitting to get this fix merged.

## Changes

- **nodes/ClaudeCode/ClaudeCode.node.ts**: Update import from `@anthropic-ai/claude-code` to `@anthropic-ai/claude-agent-sdk`
- **package.json**: 
  - Update dependency to `@anthropic-ai/claude-agent-sdk`
  - Update description to reference "Claude Agent SDK"
  - Bump version to 0.3.0
- **README.md**: Update Claude Code CLI installation instructions with current methods

## Testing

- [x] `npm run build` - TypeScript compilation successful
- [x] Tested in n8n Docker container - node loads correctly
- [x] Node appears in n8n node selector UI

## Breaking Changes

None for end users. The API surface (`query`, `SDKMessage`) remains the same - only the import package name changed.

## Related

- Anthropic renamed the SDK package: `@anthropic-ai/claude-code` → `@anthropic-ai/claude-agent-sdk`
- The old `@anthropic-ai/claude-code` package now only provides the CLI tool without module exports
